### PR TITLE
feat: add Accept header for JSON API responses in request builder

### DIFF
--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -217,6 +217,7 @@ impl GleifRequestBuilder {
             .client()
             .as_ref()
             .request(self.method.clone(), url)
+            .header("Accept", "application/vnd.api+json")
             .query(&self.query)
     }
 


### PR DESCRIPTION
Adds an Accept header with value application/vnd.api+json to all outgoing requests in the request builder. This ensures that the client only accepts responses compliant with the JSON:API specification, improving API compatibility and response validation. All requests now explicitly request JSON:API-formatted responses from the GLEIF API.