### PR TITLE
refactor: Standardize error handling by replacing specific error type…

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -86,7 +86,7 @@
 //! By incorporating [`Field`] into your application, you create more robust, readable,
 //! and maintainable code for interacting with the GLEIF API.
 
-use crate::error::{GleifError, Result};
+use crate::error::{GleifError, ParseErrorKind, Result};
 use std::{fmt, str::FromStr};
 
 /// Enum for known GLEIF API field names.
@@ -220,7 +220,7 @@ impl Field {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::error::GleifError::FieldParseError`] if the input string is not a valid field name or is not allowed.
+    /// Returns [`crate::error::GleifError::ParseError`] if the input string is not a valid field name or is not allowed.
     pub fn parse_with_allowed(input: &str, allowed: Option<&[Field]>) -> Result<Field> {
         let parsed = match input {
             "lei" => Field::Lei,
@@ -256,16 +256,18 @@ impl Field {
             "relationship.type" => Field::RelationshipType,
             "fulltext" => Field::Fulltext,
             _ => {
-                return Err(GleifError::FieldParseError(
-                    "Unknown field name".to_string(),
-                ));
+                return Err(GleifError::ParseError {
+                    kind: ParseErrorKind::Field,
+                    message: "Unknown field name".to_string(),
+                });
             }
         };
         if let Some(allowed) = allowed {
             if !allowed.contains(&parsed) {
-                return Err(GleifError::FieldParseError(
-                    "Field not allowed for this operation".to_string(),
-                ));
+                return Err(GleifError::ParseError {
+                    kind: ParseErrorKind::Field,
+                    message: "Field not allowed for this operation".to_string(),
+                });
             }
         }
         Ok(parsed)

--- a/src/value.rs
+++ b/src/value.rs
@@ -70,7 +70,7 @@
 //! of your interactions with the GLEIF API, catching potential errors related to field values
 //! at compile time or through controlled parsing.
 
-use crate::error::GleifError;
+use crate::error::{GleifError, ParseErrorKind};
 use std::{fmt, str::FromStr};
 
 // Re-exporting the enums for external use
@@ -114,9 +114,10 @@ impl FromStr for EntityCategory {
             "SOLE_PROPRIETOR" => Ok(EntityCategory::SoleProprietor),
             "RESIDENT_GOVERNMENT_ENTITY" => Ok(EntityCategory::ResidentGovernmentEntity),
             "INTERNATIONAL_ORGANIZATION" => Ok(EntityCategory::InternationalOrganization),
-            _ => Err(GleifError::ValueParseError(
-                "Unknown EntityCategory variant".to_string(),
-            )),
+            _ => Err(GleifError::ParseError {
+                kind: ParseErrorKind::Value,
+                message: "Unknown EntityCategory variant".to_string(),
+            }),
         }
     }
 }
@@ -172,9 +173,10 @@ impl FromStr for RegistrationStatus {
             "PENDING_TRANSFER" => Ok(RegistrationStatus::PendingTransfer),
             "PENDING_ARCHIVAL" => Ok(RegistrationStatus::PendingArchival),
             "PUBLISHED" => Ok(RegistrationStatus::Published),
-            _ => Err(GleifError::ValueParseError(
-                "Unknown RegistrationStatus variant".to_string(),
-            )),
+            _ => Err(GleifError::ParseError {
+                kind: ParseErrorKind::Value,
+                message: "Unknown RegistrationStatus variant".to_string(),
+            }),
         }
     }
 }
@@ -212,9 +214,10 @@ impl FromStr for ConformityFlag {
             "CONFORMING" => Ok(ConformityFlag::Conforming),
             "NON_CONFORMING" => Ok(ConformityFlag::NonConforming),
             "NOT_APPLICABLE" => Ok(ConformityFlag::NotApplicable),
-            _ => Err(GleifError::ValueParseError(
-                "Unknown ConformityFlag variant".to_string(),
-            )),
+            _ => Err(GleifError::ParseError {
+                kind: ParseErrorKind::Value,
+                message: "Unknown ConformityFlag variant".to_string(),
+            }),
         }
     }
 }


### PR DESCRIPTION
## Motivation
This PR standardizes error handling in the codebase. Previously, there were multiple specific error types for parsing fields and values, which could lead to inconsistency and duplicated logic.

## Solution
- Replaced specific error types for field and value parsing with a unified ParseError structure.
- Updated all relevant code to use the new ParseError variant, improving maintainability and clarity.
- Added new error handling in the send method